### PR TITLE
Added support for the instance customisation plugin image tag to be stored in a private repo

### DIFF
--- a/charts/instance-customisation-plugin/templates/deployment.yaml
+++ b/charts/instance-customisation-plugin/templates/deployment.yaml
@@ -35,12 +35,14 @@ spec:
       labels:
         app.kubernetes.io/name: sps-instance-customisation-plugin
     spec:
-      tolerations:
-        - operator: "Exists"
       containers:
       - image: {{ .Values.image }}
         imagePullPolicy: Always
         name: sps-instance-customisation-plugin
         ports:
         - containerPort: {{ .Values.port }}
+      {{ if and (ne .Values.imageCredentials.registry "") (ne .Values.imageCredentials.username "") (ne .Values.imageCredentials.password "") }}
+      imagePullSecrets:
+      - name: sps-instance-customisation-plugin
+      {{ end }}
 ---

--- a/charts/instance-customisation-plugin/templates/secret.yaml
+++ b/charts/instance-customisation-plugin/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}
+{{ if and (ne .Values.imageCredentials.registry "") (ne .Values.imageCredentials.username "") (ne .Values.imageCredentials.password "") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sps-instance-customisation-plugin
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{ end }}

--- a/charts/instance-customisation-plugin/values.yaml
+++ b/charts/instance-customisation-plugin/values.yaml
@@ -2,5 +2,12 @@
 # The image of the instance customisation plugin container
 image: "ghcr.io/scalablepixelstreaming/apis/instance-customisation-plugin:latest"
 
+# Credentials for the instance customisation plugin image if it is pulled from a private registry
+imageCredentials:
+  registry: ""
+  username: ""
+  password: ""
+  email: ""
+
 # The port this instance customisation plugin should listen on
 port: 55774


### PR DESCRIPTION
## Relevant components:
- [x] Helm Chart

## Problem statement:
There was no way a consumer of the helm chart could provide an image tag from a private repo

## Solution
Added support for installing the helm chart with optional `imageCredentials`. If supplied, a secret will be created with the necessary credentials and supplied on the container deployment.

## Documentation

You can install the instance customisation helm chart with the following values if your instance customisation plugin image tag is stored in a private repository
```
helm install icp ./charts/instance-customisation-plugin/ --set imageCredentials.username=MY_USERNAME --set imageCredentials.password=MY_PASSWORD --set imageCredentials.registry=MY_PRIVATE_REGISTRY --set image=MY_IMAGE
```

An example of what this might look like using Docker

```
helm install icp ./charts/instance-customisation-plugin/ --set imageCredentials.username=MY_USERNAME --set imageCredentials.password=MY_PASSWORD --set imageCredentials.registry=https://index.docker.io/v2/ --set image=docker.io/MY_COMPANY_NAME/instance-customisation-plugin:latest
```



## Test Plan and Compatibility
I have verified that installing the helm chart with the credentials set creates the secret:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: sps-instance-customisation-plugin
  namespace: default
  uid: 8a656679-078a-48fe-bd2e-4d5d322d76e9
  resourceVersion: '1431728'
  creationTimestamp: '2023-04-18T02:37:38Z'
  labels:
    app.kubernetes.io/managed-by: Helm
  annotations:
    meta.helm.sh/release-name: icp
    meta.helm.sh/release-namespace: default
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: >-
    ******REDACTED**********
```

And that the `imagePullSecrets` is applied to the deployment:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: sps-instance-customisation-plugin
  namespace: default
  uid: b8784bb7-dda2-4312-b793-5b7ce166be4d
  resourceVersion: '1431769'
  generation: 1
  creationTimestamp: '2023-04-18T02:37:38Z'
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: sps-instance-customisation-plugin
  annotations:
    deployment.kubernetes.io/revision: '1'
    meta.helm.sh/release-name: icp
    meta.helm.sh/release-namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: sps-instance-customisation-plugin
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: sps-instance-customisation-plugin
    spec:
      containers:
        - name: sps-instance-customisation-plugin
          image: docker.io/dpholden/instance-customisation-plugin:latest
          ports:
            - containerPort: 55774
              protocol: TCP
          resources: {}
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
          imagePullPolicy: Always
      restartPolicy: Always
      terminationGracePeriodSeconds: 30
      dnsPolicy: ClusterFirst
      securityContext: {}
      imagePullSecrets:
        - name: sps-instance-customisation-plugin
```