### PR TITLE
Comment out the code that adds volume mounts and provide details on what needs to be done prior to using them

### DIFF
--- a/examples/golang/instance-customisation-plugin/main.go
+++ b/examples/golang/instance-customisation-plugin/main.go
@@ -53,11 +53,13 @@ func (server *InstanceCustomisationPluginServer) UpdateRuntimeOptions(ctx contex
 	}
 
 	// Dynamically adding a volume mount to the requested instance.
-	req.RuntimeOptions.VolumeMounts = append(req.RuntimeOptions.VolumeMounts, &customisation.RuntimeOptions_VolumeMounts{
-		Name:      "my-custom-mount",
-		MountPath: "/home/ue4/my-custom-mount",
-		ReadOnly:  false,
-	})
+	// Volume mounts require a persistent volume claim to exist on the cluster prior to attempting to add volume mounts
+	// See: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+	// req.RuntimeOptions.VolumeMounts = append(req.RuntimeOptions.VolumeMounts, &customisation.RuntimeOptions_VolumeMounts{
+	// 	Name:      "my-custom-mount",
+	// 	MountPath: "/home/ue4/my-custom-mount",
+	// 	ReadOnly:  false,
+	// })
 
 	// Here is where you might do something with loading a map that was selected by the user
 	log.Println("Here is where we might load the following map: " + options.Map)


### PR DESCRIPTION
…hat needs to be done prior to using them

## Relevant components:
- [x] Examples

## Problem statement:
The example included code demonstrating how to add volume mounts to an instance using an instance customisation plugin. This was causing instances to fail scheduling due to the requirement of a `PersistentVolumeClaim` needing to exist in order for it to be mounted.

## Solution
I've commented out the code example demonstrating how to add volume mounts, so it's still a valid example. I've also offered further links to how to manage volumes in Kuberenetes.

## Documentation
N/A

## Test Plan and Compatibility
The example still compiles and runs.