### PR TITLE
Fix broken link on the "What can I customise?" page

### DIFF
--- a/docs/instance-customisation/what-can-i-customise.md
+++ b/docs/instance-customisation/what-can-i-customise.md
@@ -41,4 +41,4 @@ Volume mounts require a persistent volume claim to exist prior to attempting to 
 
 Any environment variables that you want to modify
 
-To see how you might update runtime options in your instance customisation plugin, you can refer to the [examples](examples/golang/instance-customisation-plugin) in this repository.
+To see how you might update runtime options in your instance customisation plugin, you can refer to the [examples](/examples/golang/instance-customisation-plugin) in this repository.


### PR DESCRIPTION
## Relevant components:
- [ ] Helm Chart
- [ ] Examples
- [ x ] Docs
- [ ] API

## Problem statement:
Fixes a broken link.


## Solution
Add a leading `/` that was missing in the relative url.

## Documentation
N/A

## Test Plan and Compatibility
Tested the link in Github markdown preview.
