### PR TITLE
Fixed broken links

### DIFF
--- a/docs/instance-customisation/deploy.md
+++ b/docs/instance-customisation/deploy.md
@@ -4,13 +4,13 @@ Once you have built your instance customisation plugin it needs to be deployed t
 
 ### Building a container 
 
-In order to deploy your plugin to the Scalable Pixel Streaming cluster, it first needs to be containerised. You can follow the docker guide [here](https://docs.docker.com/language/golang/build-images/) or check out the Dockerfile we have in examples [here](examples/golang/instance-customisation-plugin)
+In order to deploy your plugin to the Scalable Pixel Streaming cluster, it first needs to be containerised. You can follow the docker guide [here](https://docs.docker.com/language/golang/build-images/) or check out the Dockerfile we have in examples [here](../../examples/golang/instance-customisation-plugin)
 
 ### Deploying to the cluster
 
 Scalable Pixel Streaming is installed onto a [kubernetes](https://kubernetes.io/) cluster. The cloud platform you have installed Scalable Pixel Streaming onto will inform how you access your cluster. Refer to the [Scalable Pixel Streaming documentation](http://docs.beta.scalablestreaming.io/) for information on how to access your cluster.
 
-There is a helm chart provided in this repository available [here](charts/instance-customisation-plugin). This chart includes the necessary resources to deploy an instance customisation plugin. By default the helm chart comes with the [example plugin](examples/golang/instance-customisation-plugin) already configured.
+There is a helm chart provided in this repository available [here](../../charts/instance-customisation-plugin). This chart includes the necessary resources to deploy an instance customisation plugin. By default the helm chart comes with the [example plugin](../../examples/golang/instance-customisation-plugin) already configured.
 
 To change the helm chart to use your own containerised instance customisation plugin:
 

--- a/docs/instance-customisation/what-can-i-customise.md
+++ b/docs/instance-customisation/what-can-i-customise.md
@@ -35,10 +35,10 @@ Any additional arguments you wish to add to your application. Please note that t
 
 Mount any additional volumes to your instance, for example, unique user data. 
 
-Volume mounts require a persistent volume claim to exist prior to attempting to add volume mounts to your instances (see [https://kubernetes.io/docs/concepts/storage/persistent-volumes/](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)). If you incorrectly configure your volume mounts your application instances will fail to start.
+Volume mounts require a persistent volume claim to exist prior to attempting to add volume mounts to your instances (see [Kubernetes - Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)). If you incorrectly configure your volume mounts your application instances will fail to start.
 
 **Environment Variables**
 
 Any environment variables that you want to modify
 
-To see how you might update runtime options in your instance customisation plugin, you can refer to the [examples](examples/golang/instance-customisation-plugin) in this repository.
+To see how you might update runtime options in your instance customisation plugin, you can refer to the [examples](../../examples/golang/instance-customisation-plugin) in this repository.


### PR DESCRIPTION
## Relevant components:
- [ ] Helm Chart
- [ ] Examples
- [x] Docs
- [ ] API

## Problem statement:
There were links on the documentation that were broken

## Solution
Fixed the broken links

## Test Plan and Compatibility
Check each link with the new generated path in the browser 


